### PR TITLE
parse exists as an explicit exists constructor

### DIFF
--- a/src/ExamplesOfSemanticFunction.hs
+++ b/src/ExamplesOfSemanticFunction.hs
@@ -17,6 +17,7 @@ collectAllVariables (ArrayElem a e) = collectAllVariables a ++ collectAllVariabl
 collectAllVariables (OpNeg e)       = collectAllVariables e
 collectAllVariables (BinopExpr _ e1 e2) = collectAllVariables e1 ++ collectAllVariables e2
 collectAllVariables (Forall _ e)    = collectAllVariables e
+collectAllVariables (Exists _ e)    = collectAllVariables e
 collectAllVariables (SizeOf a)      = collectAllVariables a
 collectAllVariables (RepBy a e1 e2) = collectAllVariables a ++ collectAllVariables e1 ++ collectAllVariables e2
 collectAllVariables (Cond g e1 e2)  = collectAllVariables g ++ collectAllVariables e1 ++ collectAllVariables e2
@@ -37,7 +38,11 @@ freeVariables (BinopExpr _ e1 e2) = freeVariables e1 ++ freeVariables e2
 freeVariables (Forall x e)    = filter not_x (freeVariables e)
     where
     not_x y = y /= x
-    
+
+freeVariables (Exists x e)    = filter not_x (freeVariables e)
+    where
+    not_x y = y /= x
+
 freeVariables (SizeOf a)      = freeVariables a
 freeVariables (RepBy a e1 e2) = freeVariables a ++ freeVariables e1 ++ freeVariables e2
 freeVariables (Cond g e1 e2)  = freeVariables g ++ freeVariables e1 ++ freeVariables e2

--- a/src/GCLParser/GCLDatatype.hs
+++ b/src/GCLParser/GCLDatatype.hs
@@ -85,6 +85,7 @@ data Expr
     | OpNeg              Expr    
     | BinopExpr          BinOp  Expr   Expr
     | Forall             String Expr 
+    | Exists             String Expr 
     | SizeOf             Expr
     | RepBy              Expr   Expr   Expr
     | Cond               Expr   Expr   Expr
@@ -124,8 +125,6 @@ opDivide :: Expr -> Expr -> Expr
 opDivide = BinopExpr Divide
 opAlias :: Expr -> Expr -> Expr
 opAlias    = BinopExpr Alias
-exists_ :: String -> Expr -> Expr
-exists_ i p = OpNeg (Forall i (OpNeg p))
     
 instance Show Expr where
     show (Var var)                  = var
@@ -136,11 +135,11 @@ instance Show Expr where
     show (Dereference u)            = u ++ ".val"
     show (Parens e)                 = "(" ++ show e ++ ")"
     show (ArrayElem var index)      = show var ++ "[" ++ show index ++ "]"
-    show (OpNeg (Forall var (OpNeg p))) = "exists " ++ var ++ ":: " ++ show p
     show (OpNeg expr)               = "~" ++ show expr
     show (BinopExpr op e1 e2)       = "(" ++ show e1 ++ " " ++ show op ++ " " ++ show e2 ++ ")"
     show (NewStore e)               = "new(" ++ show e ++ ")"    
     show (Forall var p)             = "forall " ++ var ++ ":: " ++ show p
+    show (Exists var p)             = "exists " ++ var ++ ":: " ++ show p
     show (SizeOf var)               = "#" ++ show var
     show (RepBy var i val)          = show var ++ "(" ++ show i ++ " repby " ++ show val ++ ")"
     show (Cond g e1 e2)             = "(" ++ show g ++ " -> " ++ show e1 ++ " | " ++ show e2 ++ ")"

--- a/src/GCLParser/Parser.y
+++ b/src/GCLParser/Parser.y
@@ -179,8 +179,8 @@ PExpr :: { Expr }
 --       | forall identifier colon colon PExpr            { let newName = $2 ++ "'"
 --                                                              in Forall newName (rename newName $2 $5) }
 
-       | forall identifier colon colon PExpr            { Forall  $2 $5 }
-       | exists identifier colon colon PExpr            { exists_ $2 $5 }
+       | forall identifier colon colon PExpr            { Forall $2 $5 }
+       | exists identifier colon colon PExpr            { Exists $2 $5 }
 
 {
 type ParseResult a = Either String a


### PR DESCRIPTION
The negation of a universally quantified predicate cannot be represented directly in SMTLIB2. This is a problem for the way existential quantifiers were parsed.