### PR TITLE
Removed reference to ChangeLog.md in .cabal

### DIFF
--- a/GCLparser.cabal
+++ b/GCLparser.cabal
@@ -9,7 +9,7 @@ author:              Stefan Koppier, Wishnu Prasetya
 -- copyright:
 category:            Testing
 build-type:          Simple
-extra-source-files:  ChangeLog.md, README.md
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 Library


### PR DESCRIPTION
Cabal doesn't like it when building using local packages