### PR TITLE
Defining no-op mutations for several BinOps

### DIFF
--- a/src/MuGCL.hs
+++ b/src/MuGCL.hs
@@ -167,6 +167,9 @@ mutateExpr expr = filter (\m -> fst m /= NO_MUTATION) $ mutate expr
               m3 = (AOR_OR_AND, BinopExpr And e1 e2)
               in
               [m1,m2,m3]
+            Alias -> [(NO_MUTATION, expr)]
+            Implication -> [(NO_MUTATION, expr)]
+            Equal -> [(NO_MUTATION, expr)]
 
          in
          toplevel_mutants ++ group1 ++ group2


### PR DESCRIPTION
Equal, Alias and Implication did not have their cases handled, which caused several benchmarks to trigger a runtime exception.

This just makes them no-op mutations for now but I have few suitable mutations in mind, just unsure how to implement them.