### PR TITLE
Implement procedure call (syntax and interpreter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Be mindful that this tool is experimental, and is not made for performance. Ther
 
 ##### mutation test
 
-The module `MuGCL` provides a function that generate mutants of a GCP Program.
+The module `MuGCL` provides a function that generate mutants of a GCL Program.
 Given a program P, the function below generates a bunch of so-called
 mutants. Each is a program P', which is a copy of P, but where it is changed
 in one place (e.g. some expression "i<n" is mutated to "i<=n").

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ The module `GCLInterpreter` provides a function to execute a GCL program, given 
 execProgram :: Program -> State -> Either (String,State) State
 ```
 
+Another option is to provide the parameter values positionally:
+
+```Haskell
+callProgram :: Program -> [Value] -> Either String [Value]
+```
+
 Be mindful that this tool is experimental, and is not made for performance. There is also some incompleteness when interpreting the ∀ and ∃ quantifiers. Obviously, we can't actually check such a quantifier over the whole space of integers, so some practical choice was made. See the module in-code documentation.
 
 ##### mutation test

--- a/examples/E.gcl
+++ b/examples/E.gcl
@@ -1,6 +1,6 @@
 // Just a very simple example; it is faulty
+pre { 1<x }
 E(x:int | y:int){
-  assume 1<x ;
-  while 0<x do{ x:=x-1 } ; y:=x ;
-  assert y=1 // faulty
+  while 0<x do{ x:=x-1 } ; y:=x
 }
+post { y=1 } // faulty

--- a/examples/benchmark/bsort.gcl
+++ b/examples/benchmark/bsort.gcl
@@ -3,7 +3,7 @@
 // N is an experiment parameter; replace it with a concrete value.
 
 pre { #a>=0 && #a>=N }
-bsort( | a : []int) {
+bsort(a:[]int | sorted:[]int) {
   var k:int {
     k := 0 ;
     // inv of outer loop
@@ -30,6 +30,7 @@ bsort( | a : []int) {
       } ;
       k := k+1
     }
-  }
+  } ;
+  sorted := a
 }
-post { forall i:: 0<=i && i<#a ==> (forall j:: i<=j && j<#a ==> a[i]<=a[j]) }
+post { forall i:: 0<=i && i<#sorted ==> (forall j:: i<=j && j<#sorted ==> sorted[i]<=sorted[j]) }

--- a/examples/benchmark/bsort.gcl
+++ b/examples/benchmark/bsort.gcl
@@ -2,8 +2,8 @@
 
 // N is an experiment parameter; replace it with a concrete value.
 
+pre { #a>=0 && #a>=N }
 bsort( | a : []int) {
-  assume #a>=0 && #a>=N ;
   var k:int {
     k := 0 ;
     // inv of outer loop
@@ -18,17 +18,18 @@ bsort( | a : []int) {
                 && k<=m && m<#a
                 && (forall j:: m<=j && j<#a ==> a[m]<=a[j]) ;
          while k<m do {
-            if a[m]<a[m-1]
-               then {
-                  tmp := a[m] ;
-                  a[m] := a[m-1] ;
-                  a[m-1] := tmp
-               }
-               else { skip } ;
-            m := m-1 }
+            if a[m]<a[m-1] then {
+              tmp := a[m] ;
+              a[m] := a[m-1] ;
+              a[m-1] := tmp
+            } else {
+              skip
+            } ;
+            m := m-1
+         }
       } ;
-      k := k+1 }
-  } ;
-
-  assert (forall i:: 0<=i && i<#a ==> (forall j:: i<=j && j<#a ==> a[i]<=a[j]))
+      k := k+1
+    }
+  }
 }
+post { forall i:: 0<=i && i<#a ==> (forall j:: i<=j && j<#a ==> a[i]<=a[j]) }

--- a/examples/benchmark/divByN.gcl
+++ b/examples/benchmark/divByN.gcl
@@ -3,9 +3,8 @@
 
 // N is an experiment parameter; replace it with a concrete value.
 
+pre { x>1 }
 divByN(x:int | divisible:bool) {
-  // N is an experiment parameter
-  assume x>1 ;
   var k:int {
     k := 1 ;
     divisible := false ;
@@ -22,6 +21,6 @@ divByN(x:int | divisible:bool) {
       } ;
       k := k+1
     }
-  } ;
-  assert divisible = (exists m:: 0<m && m<=x && m*N = x)
+  }
 }
+post { divisible = (exists m:: 0<m && m<=x && m*N = x) }

--- a/examples/benchmark/find12.gcl
+++ b/examples/benchmark/find12.gcl
@@ -12,12 +12,12 @@
 // N is an experiment parameter; replace it with a concrete value.
 
 
+pre {
+  #a>0 && #a=N
+  && (forall i:: 0<=i && i<#a ==> a[i]>0)
+  && (forall i:: 0<=i && i<N  ==> a[i]=1)
+}
 find12(a:[]int | z:int) {
-   // N is an experiment parameter
-   assume #a>0 && #a=N
-          && (forall i:: 0<=i && i<#a ==> a[i]>0)
-          && (forall i:: 0<=i && i<N  ==> a[i]=1) ;
-
    var k:int, r:int {
      k := 0 ;
      z := -1 ;
@@ -45,6 +45,6 @@ find12(a:[]int | z:int) {
 
        k := k+1
      }
-   } ;
-   assert z>0
+   }
 }
+post { z>0 }

--- a/examples/benchmark/memberOf.gcl
+++ b/examples/benchmark/memberOf.gcl
@@ -2,10 +2,8 @@
 
 // N is an experiment parameter; replace it with a concrete value.
 
+pre { #a>=N && #a>=0 && (exists k:: 0<=k && k<#a && a[k]=x) }
 memberOf(x:int, a:[]int | found:bool) {
-   // N is an experiment parameter
-   assume #a>=N && #a>=0
-          && (exists k:: 0<=k && k<#a && a[k]=x) ; 
    var k:int {
      k := 0 ;
      found := false ;
@@ -15,6 +13,6 @@ memberOf(x:int, a:[]int | found:bool) {
           else { skip } ;
        k := k+1
      }
-   } ;
-   assert found 
-}  
+   }
+}
+post { found }

--- a/examples/benchmark/min.gcl
+++ b/examples/benchmark/min.gcl
@@ -6,10 +6,12 @@
 
 // N is an experiment parameter; replace it with a concrete value.
 
+pre {
+  #a>0 && #a=N 
+  && ~(x == null)
+  && (forall i:: 0<=i && i<#a ==> a[i]>0)
+}
 min(a:[]int, x:ref, u:ref | m:ref) {
-  assume #a>0 && #a=N 
-         && ~(x == null)
-         && (forall i:: 0<=i && i<#a ==> a[i]>0) ;
   var k:int {
      k := 0 ;
      while k<#a do {
@@ -20,6 +22,6 @@ min(a:[]int, x:ref, u:ref | m:ref) {
                         else { skip } ;
         k := k+1
      }
-  } ;
-  assert (forall i:: 0<=i && i<#a ==> m.val <= a[i])
+  }
 }
+post { forall i:: 0<=i && i<#a ==> m.val <= a[i] }

--- a/examples/benchmark/pullUp.gcl
+++ b/examples/benchmark/pullUp.gcl
@@ -4,9 +4,8 @@
 
 // N is an experiment parameter; replace it with a concrete value.
 
+pre { #a>=2 && #a=N && step>0 }
 pullUp(step:int , a:[]int | b:[]int) {
-   // N is an experiment parameter
-   assume #a>=2 && #a=N && step>0 ;
 
    if a[0] >= a[1]
       then { a[1] := a[0] + step }
@@ -21,7 +20,7 @@ pullUp(step:int , a:[]int | b:[]int) {
        k := k+1
      }
    } ;
-   b := a ;
-   // error; should be >= b[0]+#b-1. Change: bug removed.
-   assert b[N-1] >= b[0] + #b - 1
+   b := a
 }
+// error; should be >= b[0]+#b-1. Change: bug removed.
+post { b[N-1] >= b[0] + #b - 1 }

--- a/examples/even.gcl
+++ b/examples/even.gcl
@@ -1,0 +1,20 @@
+// This uses mutual recursion to check if a number is even. Supposedly valid.
+pre { x >= 0 }
+is_even(x:int | result:bool) {
+  if x = 0 then {
+    result := true
+  } else {
+    result := false  // TODO: is_odd(x-1)
+  }
+}
+post { result = (exists m:: 2*m = x) }
+
+pre { x >= 0 }
+is_odd(x:int | result:bool) {
+  if x = 0 then {
+    result := false
+  } else {
+    result := true  // TODO: is_even(x-1)
+  }
+}
+post { result = (exists m:: 2*m+1 = x) }

--- a/examples/even.gcl
+++ b/examples/even.gcl
@@ -4,17 +4,17 @@ is_even(x:int | result:bool) {
   if x = 0 then {
     result := true
   } else {
-    result := false  // TODO: is_odd(x-1)
+    (result) := is_odd(x-1)
   }
 }
-post { result = (exists m:: 2*m = x) }
+post { result = (2 * (x/2) = x) }
 
 pre { x >= 0 }
 is_odd(x:int | result:bool) {
   if x = 0 then {
     result := false
   } else {
-    result := true  // TODO: is_even(x-1)
+    (result) := is_even(x-1)
   }
 }
-post { result = (exists m:: 2*m+1 = x) }
+post { result = ~(2 * (x/2) = x) }

--- a/examples/min.gcl
+++ b/examples/min.gcl
@@ -1,6 +1,6 @@
 // This returns the minimum of two integer. Supposedly valid.
 min(x:int, y:int | z:int) {
   z := x ;
-  if y < x then { z := y } else { skip } ;
-  assert ((z = x) || (z = y)) && (z <= x) && (z <= y)
+  if y < x then { z := y } else { skip }
 }
+post { ((z = x) || (z = y)) && (z <= x) && (z <= y) }

--- a/examples/minind.gcl
+++ b/examples/minind.gcl
@@ -1,8 +1,8 @@
 // Given non-empty array `a`, this program returns an index of `a` 
 // pointing to a minimum element of `a`. 
 // Supposedly valid.
+pre { #a > 0 }
 minind(a:[]int | r:int) { 
-   assume #a > 0 ;
    var min:int, i:int {
        i   := 0;
        min := a[i]; 
@@ -15,7 +15,9 @@ minind(a:[]int | r:int) {
           else { skip };
           i := i + 1
       }
-   } ;
-   assert (0<= r) && (r < #a) &&
-          (forall i :: ((0<=i && (i< #a)) ==>  (a[i] >= a[r]))) 
+   }
+}
+post {
+  (0 <= r) && (r < #a)
+  && (forall i :: ((0<=i && (i< #a)) ==>  (a[i] >= a[r])))
 }

--- a/examples/quicksort.gcl
+++ b/examples/quicksort.gcl
@@ -1,0 +1,86 @@
+// Quicksort, using procedure calls and recursion.
+
+pre { #a>=0 }
+quicksort(a:[]int | sorted:[]int) {
+  (sorted) := qsort(a, 0, #a - 1)
+}
+post {
+  #sorted=#a
+  && (forall i:: 0<=i && i<#sorted ==> (forall j:: i<=j && j<#sorted ==> sorted[i]<=sorted[j]))
+}
+
+pre { #a>=0 && 0<=lo && hi<#a }
+qsort(a:[]int, lo:int, hi:int | sorted:[]int) {
+  sorted := a ;
+  if lo < hi then {
+    var p:int {
+      (sorted, p) := partition(sorted, lo, hi) ;
+      (sorted) := qsort(sorted, lo, p-1) ;
+      (sorted) := qsort(sorted, p+1, hi)
+    }
+  } else {
+    skip  // we're done
+  }
+}
+post {
+  #sorted = #a
+  // range is sorted
+  && (forall i:: lo<=i && i<=hi ==> (forall j:: i<=j && j<=hi ==> sorted[i]<=sorted[j]))
+  // range comes from original array
+  && (forall i:: lo<=i && i<=hi ==> (exists j:: lo<=j && j<=hi && sorted[i]=a[j]))
+  // rest is unchanged
+  && (forall i:: 0<=i && i<lo ==> sorted[i]=a[i])
+  && (forall i:: hi<i && i<#a ==> sorted[i]=a[i])
+}
+
+pre { #a>=0 && 0<=lo && lo<=hi && hi<#a }
+partition(a:[]int, lo:int, hi:int | partitioned:[]int, pos_pivot:int) {
+  partitioned := a ;
+  var i:int, j:int, pivot:int {
+    pivot := partitioned[hi] ;
+    i := lo ;
+    j := lo ;
+    while j <= hi do {
+      if partitioned[j] < pivot then {
+        (partitioned) := swap(partitioned, i, j) ;
+        i := i+1
+      } else {
+        skip
+      } ;
+      j := j+1
+    } ;
+    (partitioned) := swap(partitioned, i, hi) ;
+    pos_pivot := i
+  }
+}
+post {
+  #partitioned=#a
+  && lo<=pos_pivot && pos_pivot<=hi
+  // range below pos_pivot is <= pivot
+  && (forall i:: lo<=i && i<pos_pivot ==> partitioned[i]<=partitioned[pos_pivot])
+  // range above pos_pivot is >= pivot
+  && (forall i:: pos_pivot<i && i<=hi ==> partitioned[i]>=partitioned[pos_pivot])
+  // range comes from original array
+  && (forall i:: lo<=i && i<=hi ==> (exists j:: lo<=j && j<=hi && partitioned[i]=a[j]))
+  // rest is unchanged
+  && (forall i:: 0<=i && i<lo ==> partitioned[i]=a[i])
+  && (forall i:: hi<i && i<#a ==> partitioned[i]=a[i])
+}
+
+pre { #a>0 && 0<=i && i<#a && 0<=j && j<#a }
+swap(a:[]int, i:int, j:int | out:[]int) {
+  out := a ;
+  var tmp:int {
+      tmp  := out[i] ;
+      out[i] := out[j] ;
+      out[j] := tmp
+  }
+}
+post {
+  #out=#a
+  // elements are swapped
+  && out[i]=a[j]
+  && out[j]=a[i]
+  // rest is unchanged
+  && (forall k:: 0<=k && k<#a && ~(k=i) && ~(k=j) ==> out[k]=a[k])
+}

--- a/examples/reverse.gcl
+++ b/examples/reverse.gcl
@@ -1,12 +1,12 @@
 // This returns a copy of an array `a`, but in reverse order.
+pre { (0 <= #a) && (#a = #b) }
 reverse(a:[]int | b:[]int) {
-  assume (0 <= #a) && (#a = #b) ;
   var i:int {
       i := 0 ;
       while i < #a do {
         b[(#a-1)-i] := a[i];
         i := i + 1
       }
-  } ;
-  assert forall i :: ((0<=i) && (i<#a)) ==> (a[i] = b[(#a-1)-i])
+  }
 }
+post { forall i :: ((0<=i) && (i<#a)) ==> (a[i] = b[(#a-1)-i]) }

--- a/examples/swap.gcl
+++ b/examples/swap.gcl
@@ -2,14 +2,12 @@
 // program swaps the content of `a[i]` and `a[j]`.
 
 pre { (0<#a) && (0<=i) && (i<#a) && (0<=j) && (j<#a) }
-swap(i:int, j:int | a:[]int) {
-  var oldiVal:int, oldjVal:int, tmp:int {
-      oldiVal := a[i] ;
-      oldjVal := a[j] ;
-        
-      tmp  := a[i] ; 
-      a[i] := a[j] ;
-      a[j] := tmp ;
-      assert (a[i] = oldjVal) && (a[j] = oldiVal)
+swap(i:int, j:int, a:[]int | out:[]int) {
+  out := a ;
+  var tmp:int {
+      tmp    := out[i] ;
+      out[i] := out[j] ;
+      out[j] := tmp
   }
 }
+post { (out[i] = a[j]) && (out[j] = a[i]) }

--- a/examples/swap.gcl
+++ b/examples/swap.gcl
@@ -1,8 +1,8 @@
 // Given a non-empty array `a`, and two indices `i` and `j`, this 
 // program swaps the content of `a[i]` and `a[j]`.
 
+pre { (0<#a) && (0<=i) && (i<#a) && (0<=j) && (j<#a) }
 swap(i:int, j:int | a:[]int) {
-  assume (0<#a) && (0<=i) && (i<#a) && (0<=j) && (j<#a) ;
   var oldiVal:int, oldjVal:int, tmp:int {
       oldiVal := a[i] ;
       oldjVal := a[j] ;

--- a/src/GCLInterpreter.hs
+++ b/src/GCLInterpreter.hs
@@ -208,7 +208,7 @@ eval state expr = case expr of
     let Int n_ = arraySize a_
     if 0<=i_ && i_ < n_
        then return $ arrayRead a_ (Int i_)
-       else Left "EXC2: illegal array index"
+       else Left ("EXC2: illegal array index: " ++ show expr)
 
   OpNeg e -> do
      e_ <- eval state e
@@ -326,7 +326,7 @@ exec state stmt = case stmt of
         return state'
 
    AAssign  a index expr -> do
-        i <- valueToInt <$> eval_ state expr
+        i <- valueToInt <$> eval_ state index
         let array = state <@> a
         let Int n = arraySize array
         if 0<=i && i<n
@@ -335,7 +335,7 @@ exec state stmt = case stmt of
                 let array' = arrayUpdate i e array
                 let state' = update a array' state
                 return state'
-           else Left ("EXC2: illegal array index", state)
+           else Left ("EXC2: illegal array index: " ++ show stmt, state)
 
    Seq stmt1 stmt2 -> do
        intermediateState <- exec state stmt1

--- a/src/GCLLexer/Lexer.x
+++ b/src/GCLLexer/Lexer.x
@@ -15,6 +15,8 @@ $alpha = [a-zA-Z]		-- alphabetic characters
 
 tokens :-
     $white+			            	;
+    "pre"                           {\s -> TPre }
+    "post"                          {\s -> TPost }
     "skip"                          {\s -> TSkip }
     "assert"                        {\s -> TAssert }
     "assume"                        {\s -> TAssume }

--- a/src/GCLLexer/Token.hs
+++ b/src/GCLLexer/Token.hs
@@ -5,6 +5,8 @@ data Token
     | TIntValue  Int
     | TBoolValue Bool
 --    | TArray     Int
+    | TPre
+    | TPost
     | TNull
     | TSkip
     | TAssert

--- a/src/GCLParser/GCLDatatype.hs
+++ b/src/GCLParser/GCLDatatype.hs
@@ -25,22 +25,24 @@ data VarDeclaration
     = VarDeclaration String Type
     deriving (Show)
 
-{-
-data Procedure 
-    = Procedure String [VarDeclaration] [VarDeclaration] Expr Expr
+data Program
+    = Program
+        { procedures :: [Procedure]
+        }
     deriving (Show)
--}
 
-data Program 
-    = Program { 
---                pre    :: Expr, 
-              name   :: String 
-              , input  :: [VarDeclaration]
-              , output :: [VarDeclaration]
-              , stmt   :: Stmt
---              , procs  :: [Procedure]
---              , post   :: Expr 
-              } 
+data Procedure
+    = Procedure
+        { name          :: String
+        , input         :: [VarDeclaration]
+        , output        :: [VarDeclaration]
+        , preCondition  :: Maybe Expr
+          -- ^ Can refer to input variables only.
+        , postCondition :: Maybe Expr
+          -- ^ Can refer to input and output variables only.
+          -- Input variables will be at the state when the procedure was called.
+        , stmt          :: Stmt
+        }
     deriving (Show)
 
 data Stmt

--- a/src/GCLParser/GCLDatatype.hs
+++ b/src/GCLParser/GCLDatatype.hs
@@ -1,6 +1,6 @@
 module GCLParser.GCLDatatype where
-    
--- import Data.List
+
+import Data.List (intercalate)
 
 type Verbose = Bool
 
@@ -52,12 +52,12 @@ data Stmt
     | Assign     String           Expr   
     | AAssign    String           Expr   Expr  
     | DrefAssign String           Expr
+    | Call       [String]         String [Expr]
     | Seq        Stmt             Stmt   
     | IfThenElse Expr             Stmt   Stmt     
     | While      Expr             Stmt   
     | Block      [VarDeclaration] Stmt   
     | TryCatch   String           Stmt   Stmt
---    | Call       [String]         [Expr] String
 
 instance Show Stmt where
     show Skip                     = "skip"
@@ -66,12 +66,12 @@ instance Show Stmt where
     show (Assign var e)           = var ++ " := " ++ show e 
     show (DrefAssign var e)       = var ++ ".val := " ++ show e 
     show (AAssign var i e)        = var ++ "[" ++ show i ++ "]" ++ " := " ++ show e
+    show (Call vars f args)       = "(" ++ intercalate "," vars ++ ") := " ++ f ++ "(" ++ (intercalate "," . map show) args ++ ")"
     show (Seq s1 s2)              = show s1 ++ ";" ++ show s2 
     show (IfThenElse gaurd s1 s2) = "if " ++ show gaurd ++ " then " ++ show s1 ++ " else " ++ show s2
     show (While gaurd s)          = "while " ++ show gaurd ++ " do {" ++ show s ++ "}"
     show (Block vars s)           = "var " ++ show vars ++ " {" ++ show s ++ "}"
     show (TryCatch e s1 s2)         = "try { " ++ show s1 ++ " } catch(" ++ e ++ "){ " ++ show s2 ++ " }"
---    show (Call vars args f)       = "(" ++ intercalate "," vars ++ ") := " ++ "(" ++ (intercalate "," . map show) args ++ ")"
     
 -----------------------------------------------------------------------------
 -- Expressions

--- a/src/GCLParser/Parser.y
+++ b/src/GCLParser/Parser.y
@@ -18,6 +18,8 @@ import Debug.Trace
     identifier       { TIdent     $$     }
     intvalue         { TIntValue  $$     }
     boolvalue        { TBoolValue $$     }
+    pre              { TPre              }
+    post             { TPost             }
     skip             { TSkip             }
     assert           { TAssert           }
     assume           { TAssume           }
@@ -83,22 +85,24 @@ import Debug.Trace
 -- | Program parsing
 
 PProgram    :: { Program }
---             : PConditions identifier popen PVarDeclarations bar PVarDeclarations pclose copen PStatements cclose PConditions PProcedures
---                { Program $1 $2 $4 $6 $9 $12 $11 }
-             : identifier popen PVarDeclarations bar PVarDeclarations pclose copen PStatements cclose 
-                { Program $1 $3 $5 $8 }
+             : PProcedures
+                { Program $1 }
 
---PProcedures :: { [Procedure] }
---             : PProcedure PProcedures { $1 : $2 }
---             | PProcedure             { [$1] }
---             |                        { [] }
+PProcedures :: { [Procedure] }
+             : PProcedure PProcedures { $1 : $2 }
+             | PProcedure             { [$1] }
 
---PProcedure :: { Procedure }
---              : PConditions identifier popen PVarDeclarations bar PVarDeclarations pclose PConditions
---                 { Procedure $2 $4 $6 $1 $8 }
+PProcedure :: { Procedure }
+            : PPreCondition identifier popen PVarDeclarations bar PVarDeclarations pclose copen PStatements cclose PPostCondition
+                 { Procedure $2 $4 $6 $1 $11 $9 }
 
---PConditions :: { Expr }
---             : copen PExpr cclose { $2 }
+PPreCondition :: { Maybe Expr }
+               : pre copen PExpr cclose { Just $3 }
+               |                        { Nothing }
+
+PPostCondition :: { Maybe Expr }
+                : post copen PExpr cclose { Just $3 }
+                |                         { Nothing }
 
 PVarDeclarations :: { [VarDeclaration] }
                   : PVarDeclaration comma PVarDeclarations { $1 : $3 }

--- a/src/GCLParser/Parser.y
+++ b/src/GCLParser/Parser.y
@@ -127,10 +127,10 @@ PStatements :: { Stmt }
              : PStatements semicolon PStatements { Seq $1 $3 }
              | PStatement                        { $1 }
 
---PArguments :: { [Expr] }
---            : PExpr comma PArguments { $1 : $3 }
---            | PExpr                  { [$1] }
---            |                        { [] }
+PArguments :: { [Expr] }
+            : PExpr comma PArguments { $1 : $3 }
+            | PExpr                  { [$1] }
+            |                        { [] }
 
 PStatement  :: { Stmt }
              : skip                                                   { Skip }
@@ -143,7 +143,7 @@ PStatement  :: { Stmt }
              | identifier sopen PExpr sclose assign PExpr             { AAssign $1 $3 $6 }
              | identifier assign PExpr                                { Assign $1 $3 }
              | identifier dot val assign PExpr                        { DrefAssign $1 $5 }
---           | popen PIdentifiers pclose assign identifier popen PArguments pclose { Call $2 $7 $5 }
+             | popen PIdentifiers pclose assign identifier popen PArguments pclose { Call $2 $5 $7 }
 
 PIdentifiers :: { [String] }
               : identifier comma PIdentifiers { $1 : $3 }

--- a/src/GCLParser/PrettyPrint.hs
+++ b/src/GCLParser/PrettyPrint.hs
@@ -23,8 +23,8 @@ ppProcedure Procedure {name,input,output,preCondition,postCondition,stmt}
         pre   p = text "pre {" <> ppExpr p <> char '}'
         post  p = text "post {" <> ppExpr p <> char '}'
         args    = input' <> text " | " <> output'
-        input'  = ppVarDeclarations input
-        output' = ppVarDeclarations output
+        input'  = commaSeparated ppVarDeclaration input
+        output' = commaSeparated ppVarDeclaration output
 
 
 ppExpr :: Expr -> Doc
@@ -38,6 +38,7 @@ ppStmt (Assume e)           = text "assume " <> ppExpr e
 ppStmt (Assign x e)         = text x <> text " := " <> ppExpr e
 ppStmt (DrefAssign x e)     = text x <> text ".val := " <> ppExpr e
 ppStmt (AAssign x i e)      = text x <> char '[' <> ppExpr i <> char ']' <> text " := " <> ppExpr e
+ppStmt (Call vars f args)   = text "(" <> commaSeparated text vars <> text ") := " <> text f <> text "(" <> commaSeparated ppExpr args <> text ")"
 ppStmt (Seq s1 s2)          = ppStmt s1 <> char ';' $+$ ppStmt s2
 ppStmt (IfThenElse g s1 s2) =   text "if " <> ppExpr g <> text " then {"
                             $+$ tab (ppStmt s1)
@@ -52,11 +53,9 @@ ppStmt (TryCatch e s h) = text "try{ "
                           $+$ text ("catch(" ++ e ++ "){")
                           $+$ tab (ppStmt h <> text "}")     
                                             
-ppStmt (Block vardecls s) = (text "var " <> ppVarDeclarations vardecls <> text " {")
+ppStmt (Block vardecls s) = (text "var " <> commaSeparated ppVarDeclaration vardecls <> text " {")
                           $+$ tab (ppStmt s <> text "}")
 
-ppVarDeclarations :: [VarDeclaration] -> Doc
-ppVarDeclarations = hcat . intersperse comma . map ppVarDeclaration
 
 ppVarDeclaration :: VarDeclaration -> Doc
 ppVarDeclaration (VarDeclaration s t)
@@ -73,3 +72,6 @@ ppPrimitiveType PTBool = text "bool"
 
 tab :: Doc -> Doc
 tab = nest 4
+
+commaSeparated :: (a -> Doc) -> [a] -> Doc
+commaSeparated f = hcat . intersperse comma . map f

--- a/src/GCLParser/PrettyPrint.hs
+++ b/src/GCLParser/PrettyPrint.hs
@@ -10,11 +10,18 @@ ppProgram2String :: Program -> String
 ppProgram2String prg = show . ppProgram $ prg
 
 ppProgram :: Program -> Doc
-ppProgram Program {name,input,output,stmt}
-    =   (text name <> char '(' <> args <> text ") {")
+ppProgram = vcat . intersperse (text "") . map ppProcedure . procedures
+
+ppProcedure :: Procedure -> Doc
+ppProcedure Procedure {name,input,output,preCondition,postCondition,stmt}
+    =   maybe mempty pre preCondition
+    $+$ (text name <> char '(' <> args <> text ") {")
     $+$ tab (ppStmt stmt)
     $+$ char '}'
+    $+$ maybe mempty post postCondition
     where
+        pre   p = text "pre {" <> ppExpr p <> char '}'
+        post  p = text "post {" <> ppExpr p <> char '}'
         args    = input' <> text " | " <> output'
         input'  = ppVarDeclarations input
         output' = ppVarDeclarations output

--- a/src/GCLUtils.hs
+++ b/src/GCLUtils.hs
@@ -15,5 +15,6 @@ import MuGCL
 echoTestParser :: String -> IO()
 echoTestParser filename = do
    gcl <- parseGCLfile filename
-   let (Right prg) = gcl
-   putStrLn . ppProgram2String $ prg
+   case gcl of
+    Right prg -> putStrLn . ppProgram2String $ prg
+    Left err -> error $ "failed parsing " ++ filename ++ ": " ++ err

--- a/src/MuGCL.hs
+++ b/src/MuGCL.hs
@@ -85,12 +85,12 @@ data MutationType = NO_MUTATION |
 f $> (a,x) = (a, f x)
 
 mutateExpr :: Expr -> [(MutationType,Expr)]
-mutateExpr expr = filter (\m -> fst m /= NO_MUTATION) $ mutate expr
+mutateExpr = filter (\m -> fst m /= NO_MUTATION) . mutate
    where
    mutate expr = case expr of
-      Var v   -> [(NO_MUTATION, expr)]
-      LitI x  -> [(NO_MUTATION, expr)]
-      LitB x  -> [(NO_MUTATION, expr)]
+      Var _   -> [(NO_MUTATION, expr)]
+      LitI _  -> [(NO_MUTATION, expr)]
+      LitB _  -> [(NO_MUTATION, expr)]
       LitNull -> [(NO_MUTATION, expr)]
       Parens e ->  [ Parens $> e' | e' <- mutate e]
       ArrayElem a i ->
@@ -207,15 +207,15 @@ mutateExpr expr = filter (\m -> fst m /= NO_MUTATION) $ mutate expr
 
       NewStore e -> map (NewStore $>) $ mutate e
 
-      Dereference p -> [(NO_MUTATION, expr)]
+      Dereference _ -> [(NO_MUTATION, expr)]
 
 mutateStmt :: Stmt -> [(MutationType,Stmt)]
-mutateStmt stmt = filter (\m -> fst m /= NO_MUTATION) $ mutate stmt
+mutateStmt = filter (\m -> fst m /= NO_MUTATION) . mutate
   where
   mutate stmt = case stmt of
      Skip     -> [(NO_MUTATION, stmt)]
-     Assert e -> [(NO_MUTATION, stmt)]
-     Assume e -> [(NO_MUTATION, stmt)]
+     Assert _ -> [(NO_MUTATION, stmt)]
+     Assume _ -> [(NO_MUTATION, stmt)]
      Assign  x e    -> map (Assign x $>) $ mutateExpr e
      DrefAssign x e -> map (DrefAssign x $>) $ mutateExpr e
      AAssign x i e -> map ((\i_ -> AAssign x i_ e) $>) (mutateExpr i)
@@ -260,6 +260,7 @@ mutateProgram (Program name inputParams outputParams body)
 
 
 -- tests
+test_ :: IO ()
 test_ = do
    gcl <- parseGCLfile "../examples/benchmark/bsort.gcl"
    let (Right prg) = gcl

--- a/src/MuGCL.hs
+++ b/src/MuGCL.hs
@@ -253,10 +253,20 @@ mutateStmt = filter (\m -> fst m /= NO_MUTATION) . mutate
         m1 : group1 ++ group2
 
 
-mutateProgram :: Program -> [(MutationType,Program)]
-mutateProgram (Program name inputParams outputParams body)
+mutateProgram :: Program -> [(MutationType, Program)]
+mutateProgram = map (Program $>) . mutate . procedures
+  where
+    mutate :: [Procedure] -> [(MutationType, [Procedure])]
+    mutate [] = []
+    mutate (proc : procs) =
+      map ((: procs) $>) (mutateProcedure proc)
+      ++ map ((proc :) $>) (mutate procs)
+
+
+mutateProcedure :: Procedure -> [(MutationType, Procedure)]
+mutateProcedure (Procedure name inputParams outputParams pre post body)
    =
-   map (Program name inputParams outputParams $>) $ mutateStmt body
+   map (Procedure name inputParams outputParams pre post $>) $ mutateStmt body
 
 
 -- tests


### PR DESCRIPTION
Just something I changed for our implementation, but maybe you want to take some of it? If you only want a part, I can make smaller PRs for subsets of the changes.

I made the pre- and postconditions explicit to allow using them to handle program calls.

Another change was to strictly separate between input and output variables, you can't be both at the same time (see e.g. `swap.gcl`). So now you can't just mutate an array you were passed, but have to return the modified version. Otherwise (3.12) in the lecture notes wouldn't work and the syntax would be quite weird too. Also, this allows us to specify postconditions involving both the input and output variable, which is quite useful (see `swap.gcl` again).

Something I'm not quite sure about is how to deal with mutation of the input variables. The way the interpreter works now, nothing prevents a procedure from modifying input variables, but those changes will not have any effect for the procedure caller (i.e. they only modify local copies of the input variables).
If we assume input variables are never mutated, everything is alright, but if they are mutated, we have quite a few things to think about:

I would argue now that the postcondition should always refer to the initial state of the input variables. It's an external interface of the procedure and shouldn't care about internal modifications to variables (otherwise, treating the procedure as `Pr(x | r1, r2 ) { assert P; assume Q }` doesn't work).
But if we do that, it makes the verification of a procedure a bit more complicated, since you can't just append the postcondition as an assert (it would see the mutated input variables). You would need to introduce additional local variables and scope. This would make the project a bit harder for everyone.

Happy to discuss this in more detail.